### PR TITLE
Fix chip upload test

### DIFF
--- a/td_toolkits_v3/products/tests/test_views.py
+++ b/td_toolkits_v3/products/tests/test_views.py
@@ -23,7 +23,10 @@ def test_chip_batch_create_view(client, user):
 
     # Product import
     with open(PRODUCT_TEST_FILE_DIR, 'rb') as fp:
-        form_data = {'chips': fp}
+        form_data = {
+            'chips': fp,
+            'fab': ('rdl', 'rdl')
+        }
         client.post(reverse('products:chip_upload'), form_data)
 
     # check all chip is add


### PR DESCRIPTION
The Chip upload page had added a new field, which cause the old test
to fail.
close #5 